### PR TITLE
Cmessage sharedptr

### DIFF
--- a/src/index_view.cc
+++ b/src/index_view.cc
@@ -22,6 +22,7 @@
 #include "config.h"
 #include "lua.h"
 #include "index_view.h"
+#include "message_lua.h"
 #include "global_state.h"
 #include "screen.h"
 
@@ -76,11 +77,7 @@ std::string CIndexView::format(std::shared_ptr<CMessage> cur)
     // TODO: Fix this properly - we need to use a shared_ptr for the
     // maildir_object.
     //
-    CMessage **udata = (CMessage **) lua_newuserdata(l, sizeof(CMessage *));
-    *udata = new CMessage(cur->path());
-    luaL_getmetatable(l, "luaL_CMessage");
-    lua_setmetatable(l, -2);
-
+    push_cmessage(l, cur);
 
     /**
      * Now call "to_string"

--- a/src/maildir_lua.cc
+++ b/src/maildir_lua.cc
@@ -43,6 +43,7 @@ extern "C"
 #include "file.h"
 #include "maildir.h"
 #include "message.h"
+#include "message_lua.h"
 
 
 
@@ -154,11 +155,7 @@ int l_CMaildir_messages(lua_State * l)
     for (std::vector < std::string >::iterator it = tmp.begin();
             it != tmp.end(); ++it)
     {
-        CMessage **udata =
-            (CMessage **) lua_newuserdata(l, sizeof(CMessage *));
-        *udata = new CMessage(*it);
-        luaL_getmetatable(l, "luaL_CMessage");
-        lua_setmetatable(l, -2);
+        push_cmessage(l, std::shared_ptr<CMessage>(new CMessage(*it)));
         lua_rawseti(l, -2, i + 1);
 
         i++;

--- a/src/message_lua.cc
+++ b/src/message_lua.cc
@@ -46,12 +46,10 @@ extern "C"
 
 
 /**
- * Binding for CMessage
+ * Push a CMessage pointer onto the Lua stack.
  */
-int l_CMessage_constructor(lua_State * l)
+void push_cmessage(lua_State * l, std::shared_ptr<CMessage> message)
 {
-    const char *name = luaL_checkstring(l, 1);
-
     /**
      * Allocate a new object.
      */
@@ -59,7 +57,7 @@ int l_CMessage_constructor(lua_State * l)
     if (!ud)
     {
         /* Error - couldn't allocate the memory */
-        return 0;
+        return;
     }
     /* We can't just do *(shared_ptr<...> *)ud = shared_ptr<>... since
      * it will try to call the assignment operator on the object at *ud,
@@ -74,10 +72,20 @@ int l_CMessage_constructor(lua_State * l)
      * Now that we have a valid shared_ptr pointing to nothing, we can
      * assign the final value to it.
      */
-    *udata = std::shared_ptr<CMessage>(new CMessage(name));
+    *udata = message;
 
     luaL_getmetatable(l, "luaL_CMessage");
     lua_setmetatable(l, -2);
+}
+
+/**
+ * Binding for CMessage
+ */
+int l_CMessage_constructor(lua_State * l)
+{
+    const char *name = luaL_checkstring(l, 1);
+
+    push_cmessage(l, std::shared_ptr<CMessage>(new CMessage(name)));
 
     return 1;
 }

--- a/src/message_lua.cc
+++ b/src/message_lua.cc
@@ -1,5 +1,5 @@
 /**
- * $FILENAME - $TITLE
+ * message_lua.cc - Bindings for the CMessage C++ object.
  *
  * This file is part of lumail - http://lumail.org/
  *
@@ -52,22 +52,24 @@ int l_CMessage_constructor(lua_State * l)
 {
     const char *name = luaL_checkstring(l, 1);
 
-    CMessage **udata = (CMessage **) lua_newuserdata(l, sizeof(CMessage *));
-    *udata = new CMessage(name);
+    /**
+     * Allocate a new object.
+     */
+    std::shared_ptr<CMessage> *udata = (std::shared_ptr<CMessage> *)lua_newuserdata(l, sizeof(std::shared_ptr<CMessage>*));
+    *udata = std::shared_ptr<CMessage>(new CMessage(name));
 
     luaL_getmetatable(l, "luaL_CMessage");
-
     lua_setmetatable(l, -2);
 
     return 1;
 }
 
 /**
- * Test that the object is a CMessage.
+ * Test that the object is a std::shared_ptr<CMessage>.
  */
-CMessage * l_CheckCMessage(lua_State * l, int n)
+std::shared_ptr<CMessage> *l_CheckCMessage(lua_State * l, int n)
 {
-    return *(CMessage **) luaL_checkudata(l, n, "luaL_CMessage");
+    return (std::shared_ptr<CMessage>*) luaL_checkudata(l, n, "luaL_CMessage");
 }
 
 /**
@@ -75,9 +77,8 @@ CMessage * l_CheckCMessage(lua_State * l, int n)
  */
 int l_CMessage_path(lua_State * l)
 {
-    CMessage *foo = l_CheckCMessage(l, 1);
-
-    lua_pushstring(l, foo->path().c_str());
+    std::shared_ptr<CMessage> *foo = l_CheckCMessage(l, 1);
+    lua_pushstring(l, (*foo)->path().c_str());
     return 1;
 }
 
@@ -86,11 +87,11 @@ int l_CMessage_path(lua_State * l)
  */
 int l_CMessage_header(lua_State * l)
 {
-    CMessage *foo = l_CheckCMessage(l, 1);
+    std::shared_ptr<CMessage> *foo = l_CheckCMessage(l, 1);
 
     /* Get the header. */
     const char *str = luaL_checkstring(l, 2);
-    std::string result = foo->header(str);
+    std::string result = (*foo)->header(str);
 
     /* set the retulr */
     lua_pushstring(l, result.c_str());
@@ -106,8 +107,8 @@ int l_CMessage_headers(lua_State * l)
     /**
      * Get the headers.
      */
-    CMessage *foo = l_CheckCMessage(l, 1);
-    std::unordered_map < std::string, std::string > headers = foo->headers();
+    std::shared_ptr<CMessage> *foo = l_CheckCMessage(l, 1);
+    std::unordered_map < std::string, std::string > headers = (*foo)->headers();
 
 
     /**
@@ -142,12 +143,12 @@ int l_CMessage_headers(lua_State * l)
  */
 int l_CMessage_parts(lua_State * l)
 {
-    CMessage *foo = l_CheckCMessage(l, 1);
+    std::shared_ptr<CMessage> *foo = l_CheckCMessage(l, 1);
 
     /**
      * Get the parts, and count.
      */
-    std::vector < CMessagePart * >parts = foo->get_parts();
+    std::vector < CMessagePart * >parts = (*foo)->get_parts();
 
     lua_createtable(l, parts.size(), 0);
     int i = 0;
@@ -173,7 +174,7 @@ int l_CMessage_parts(lua_State * l)
  */
 int l_CMessage_flags(lua_State * l)
 {
-    CMessage *foo = l_CheckCMessage(l, 1);
+    std::shared_ptr<CMessage> *foo = l_CheckCMessage(l, 1);
 
     /**
      * Are we setting the flags?
@@ -183,13 +184,13 @@ int l_CMessage_flags(lua_State * l)
     if (n > 1)
     {
         const char *update = luaL_checkstring(l, 1);
-        foo->set_flags(update);
+        (*foo)->set_flags(update);
     }
 
     /**
      * Now get the flags
      */
-    lua_pushstring(l, foo->get_flags().c_str());
+    lua_pushstring(l, (*foo)->get_flags().c_str());
     return 1;
 }
 
@@ -198,9 +199,8 @@ int l_CMessage_flags(lua_State * l)
  */
 int l_CMessage_destructor(lua_State * l)
 {
-    CMessage *foo = l_CheckCMessage(l, 1);
-    delete foo;
-
+  //    std::shared_ptr<CMessage> *foo = l_CheckCMessage(l, 1);
+  //    delete(foo);
     return 0;
 }
 

--- a/src/message_lua.h
+++ b/src/message_lua.h
@@ -1,0 +1,26 @@
+/**
+ * message_lua.cc - Bindings for the CMessage C++ object.
+ *
+ * This file is part of lumail - http://lumail.org/
+ *
+ * Copyright (c) 2015 by Steve Kemp.  All rights reserved.
+ *
+ **
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 dated June, 1991, or (at your
+ * option) any later version.
+ *
+ * On Debian GNU/Linux systems, the complete text of version 2 of the GNU
+ * General Public License can be found in `/usr/share/common-licenses/GPL-2'
+ */
+
+extern "C"
+{
+#include <lua.h>
+}
+#include "message.h"
+#include <memory>
+
+extern void push_cmessage(lua_State * l, std::shared_ptr<CMessage> message);

--- a/src/message_view.cc
+++ b/src/message_view.cc
@@ -25,6 +25,7 @@
 #include "global_state.h"
 #include "lua.h"
 #include "message.h"
+#include "message_lua.h"
 #include "message_view.h"
 #include "screen.h"
 
@@ -81,10 +82,7 @@ std::vector<std::string> CMessageView::get_message(std::shared_ptr<CMessage> msg
     //
     // TODO: Fix this properly
     //
-    CMessage **udata = (CMessage **) lua_newuserdata(l, sizeof(CMessage *));
-    *udata = new CMessage(msg->path());
-    luaL_getmetatable(l, "luaL_CMessage");
-    lua_setmetatable(l, -2);
+    push_cmessage(l, msg);
 
 
     /**

--- a/src/screen_lua.cc
+++ b/src/screen_lua.cc
@@ -26,6 +26,7 @@ extern "C"
 
 
 
+#include "message_lua.h"
 #include "global_state.h"
 #include "screen.h"
 
@@ -87,10 +88,7 @@ int l_CScreen_message(lua_State * l)
     CGlobalState *state = CGlobalState::instance();
     std::shared_ptr<CMessage> m = state->current_message();
 
-    CMessage **udata = (CMessage **) lua_newuserdata(l, sizeof(CMessage *));
-    *udata = new CMessage(m->path());
-    luaL_getmetatable(l, "luaL_CMessage");
-    lua_setmetatable(l, -2);
+    push_cmessage(l, m);
 
     return 1;
 }


### PR DESCRIPTION
Switch to using shared_ptr<CMessage> when passing to Lua, instead of bare pointers.  I think I've caught all cases, although there are some loose ends (eg push_cmessage() doesn't return an error if lua_newuserdata() doesn't fail).