### PR TITLE
lumail.lua: fix Message:to_ctime()

### DIFF
--- a/lumail2.lua
+++ b/lumail2.lua
@@ -506,7 +506,7 @@ function Message:to_ctime()
       local date = luarocks_libraries["date"]
 
       -- Call the data function
-      local success,output = pcall( date, str )
+      local success,output = pcall( date, d )
 
       -- If it worked, get the age in seconds, and update the cahce
       if ( success == true ) then


### PR DESCRIPTION
pcall gets a parameter which is not defined.
Use the "Date" header entry, stored in d, instead.

fixes #151 