### PR TITLE
util.h: include vector to fix build

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -21,6 +21,7 @@
 
 #include <algorithm>
 #include <sstream>
+#include <vector>
 
 
 /**


### PR DESCRIPTION
util.h uses std::vector without including it.

fixes #153