### PR TITLE
luamail2.lua: fix get_mime_viewer()

### DIFF
--- a/lumail2.lua
+++ b/lumail2.lua
@@ -270,8 +270,11 @@ end
 function get_mime_viewer( mime_type )
    local ret  = "less %s"
 
+    -- Mailcap file
+    local mailcap_file = "/etc/mailcap"
+
    -- Return if the file doesn't exist.
-   if ( not File:exists( "/etc/mailcap" ) ) then
+   if ( not File:exists( mailcap_file ) ) then
       return( ret )
    end
 
@@ -281,10 +284,10 @@ function get_mime_viewer( mime_type )
       return(ret)
    end
 
-   local f    = io.input ("/etc/mailcap")
+   local f    = io.input ( mailcap_file )
    local line = nil
 
-   for line in io.lines(file) do
+   for line in io.lines() do
 
       --
       -- Split the line by ";", and if that worked


### PR DESCRIPTION
I have another one for you.

At lumail2.lua:287 io.lines() is called with the argument "file" which is not defined.

io.input() sets the opened file as default file descriptor, so io.lines()
needs no argument at all.

**Additional changes:**

Store the path to the mailcap file in the local variable "mailcap_file".

Maybe this should be a global variable for easier modification by the user.

fixes #163 