### PR TITLE
lib/cache.lua: convert cache entries to strings before calling gsub

### DIFF
--- a/lib/cache.lua
+++ b/lib/cache.lua
@@ -153,7 +153,14 @@ function Cache.save(self)
       -- Now the key/values from our cache.
       for key,val in pairs(self.store) do
 
+         if ( type(key) ~= "string" ) then
+            key = tostring(key)
+         end
          key = key:gsub( "\"", "\\\"" )
+
+         if ( type(val) ~= "string" ) then
+            val = tostring(val)
+         end
          val = val:gsub( "\"", "\\\"" )
 
          hand:write( "CacheEntry{ key = \"" .. key .. "\", val=\"" .. val .. "\"}\n" );


### PR DESCRIPTION
This implements the first solution mentioned in #245.

Closes #245.