### PR TITLE
lumail2.lua: change wrong variable name in generate_signature()

### DIFF
--- a/lumail2.lua
+++ b/lumail2.lua
@@ -970,7 +970,7 @@ function Message.generate_signature ()
 
   -- strip anything except the address, by looking between: <>
   -- i.e. "Steve Kemp" <steve@example.com> becomes steve@example.com
-  sender = string.match(sender, "<(.*)>") or addr
+  sender = string.match(sender, "<(.*)>") or sender
 
   -- get the domain, lowercase it.
   domain = string.sub(sender, string.find(sender, "@") + 1)


### PR DESCRIPTION
fixes #259 