### PR TITLE
lumail2.lua: adapt the reply() info to the one of compose()

### DIFF
--- a/lumail2.lua
+++ b/lumail2.lua
@@ -1377,7 +1377,7 @@ Date: ${date}
 
       -- Send the mail.
       os.execute(Config:get "global.mailer" .. " < " .. tmp)
-      Panel:append "Message sent"
+      Panel:append("$[RED]INFO: $[WHITE]Reply sent to " .. to)
 
       --
       -- Since we've sent the message we need to add the "(R)eplied"


### PR DESCRIPTION
I noticed that the information printed to `Panel` differ between reply() and compose().