### PR TITLE
lumail2.lua: fix UI Behaviour after deletion

### DIFF
--- a/lumail2.lua
+++ b/lumail2.lua
@@ -1556,14 +1556,14 @@ function Message.delete ()
 
   if mode == "message" then
     -- select next message
-    if msg_index < (#global_msgs) then
-      Global:select_message(global_msgs[msg_index + 1])
+    if msg_index <= (#global_msgs) then
+      Global:select_message(global_msgs[msg_index])
     end
 
   elseif mode == "index" then
     -- if deleting the last message move the selection down.
-    if msg_index >= (#global_msgs - 1) then
-      Config:set("index.current", msg_index - 2)
+    if msg_index >= (#global_msgs) then
+      Config:set("index.current", #global_msgs - 1)
     end
   end
 end


### PR DESCRIPTION
This fixed both broken cases.
fixes #266.

* in message view we now select the message with the same index as the deleted, which is the next.
    * [1,2,[3],4] => [1,2,[4]] => [1,2]
* In index view if the current index is bigger or equal to our message count we move it to the last message.
    * [1,2,_3,4] => [1,2,_4] => [1,_2]
    * #=4; i=2     => #=3; i=2 => #=2; i=1
